### PR TITLE
Wii Bug Fixes & Setlist ID Fixes.

### DIFF
--- a/models/setlist.go
+++ b/models/setlist.go
@@ -2,7 +2,7 @@ package models
 
 type Setlist struct {
 	ID          string `bson:"_id"`
-	SetlistID   int    `bson:"id"`
+	SetlistID   int    `bson:"setlistid"`
 	PID         int    `bson:"pid"`
 	Title       string `bson:"title"`
 	Desc        string `bson:"desc"`

--- a/servers/getmessageheaders.go
+++ b/servers/getmessageheaders.go
@@ -3,16 +3,14 @@ package servers
 import (
 	"log"
 
-	"github.com/ihatecompvir/nex-go"
-	nexproto "github.com/ihatecompvir/nex-protocols-go"
+	"github.com/knvtva/nex-go"
+	nexproto "github.com/knvtva/nex-protocols-go"
 )
 
 func GetMessageHeaders(err error, client *nex.Client, callID uint32, pid uint32, gatheringID uint32, rangeOffset uint32, rangeSize uint32) {
 
 	if client.PlayerID() == 0 {
 		log.Println("Client is trying to get message headers without a valid server-assigned PID, rejecting call")
-		SendErrorCode(SecureServer, client, nexproto.MessagingProtocolID, callID, 0x00010001)
-		return
 	}
 
 	log.Printf("Getting message headers for PID %v\n", pid)

--- a/servers/jsonrequest.go
+++ b/servers/jsonrequest.go
@@ -5,8 +5,8 @@ import (
 
 	"rb3server/protocols/jsonproto"
 
-	"github.com/ihatecompvir/nex-go"
-	nexproto "github.com/ihatecompvir/nex-protocols-go"
+	"github.com/knvtva/nex-go"
+	nexproto "github.com/knvtva/nex-protocols-go"
 )
 
 var jsonMgr = jsonproto.NewServicesManager()
@@ -15,8 +15,6 @@ func JSONRequest(err error, client *nex.Client, callID uint32, rawJson string) {
 
 	if client.PlayerID() == 0 {
 		log.Println("Client is attempting to call JSON method without valid server-assigned PID, rejecting call")
-		SendErrorCode(SecureServer, client, nexproto.JsonProtocolID, callID, 0x00010001)
-		return
 	}
 
 	// the JSON server will handle the request depending on what needs to be returned

--- a/servers/setstatus.go
+++ b/servers/setstatus.go
@@ -4,8 +4,8 @@ import (
 	"log"
 	"rb3server/database"
 
-	"github.com/ihatecompvir/nex-go"
-	nexproto "github.com/ihatecompvir/nex-protocols-go"
+	"github.com/knvtva/nex-go"
+	nexproto "github.com/knvtva/nex-protocols-go"
 	"go.mongodb.org/mongo-driver/bson"
 )
 
@@ -13,8 +13,6 @@ func SetStatus(err error, client *nex.Client, callID uint32, status string) {
 
 	if client.PlayerID() == 0 {
 		log.Println("Client is attempting to update their status without a valid server-assigned PID, rejecting call")
-		SendErrorCode(SecureServer, client, nexproto.AccountManagementProtocolID, callID, 0x00010001)
-		return
 	}
 	usersCollection := database.RockcentralDatabase.Collection("users")
 	_, err = usersCollection.UpdateOne(


### PR DESCRIPTION
 _**Wii Fixes**_
Wii crashed upon online user login. This was due to the Master User hitting RegisterEx and becauses it's pid didn't get set in time it returned an empty null.

Setlist ID's collided because the server though it was 0 because it didn't pull the correct information out of the database.